### PR TITLE
Fix code scanning alert no. 9: Missing rate limiting

### DIFF
--- a/Server/index.js
+++ b/Server/index.js
@@ -3,6 +3,7 @@ const { Colors } = require('discord.js');
 const DJS = require('discord.js');
 const client = require('../client');
 const express = require('express');
+const rateLimit = require('express-rate-limit');
 const app = express();
 const port = 8923;
 const axios = require('axios');
@@ -10,6 +11,16 @@ const path = require('path');
 const { execSync } = require('child_process');
 
 app.use(express.json());
+
+// Set up rate limiter: maximum of 100 requests per 15 minutes
+const limiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // limit each IP to 100 requests per windowMs
+});
+
+// Apply rate limiter to specific routes
+app.use('/md/privacy', limiter);
+app.use('/md/tos', limiter);
 
 app.get('/api/status', (req, res) => {
     // Status type not defined so send all data about the client

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "express": "^4.21.1",
     "node-html-parser": "^6.1.10",
     "rss-to-json": "^2.1.1",
-    "wokcommands": "^2.1.9"
+    "wokcommands": "^2.1.9",
+    "express-rate-limit": "^7.4.1"
   }
 }


### PR DESCRIPTION
Fixes [https://github.com/DaalBot/Discord/security/code-scanning/9](https://github.com/DaalBot/Discord/security/code-scanning/9)

To fix the problem, we will introduce rate limiting to the Express application using the `express-rate-limit` package. This will limit the number of requests that can be made to the server within a specified time window, thereby reducing the risk of a denial-of-service attack.

1. Install the `express-rate-limit` package.
2. Import the `express-rate-limit` package in the `Server/index.js` file.
3. Set up a rate limiter with appropriate configuration (e.g., maximum of 100 requests per 15 minutes).
4. Apply the rate limiter to the specific route handlers that perform file system access.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
