### PR TITLE
Potential fix for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -1,5 +1,7 @@
 name: commit
 run-name: ${{ github.actor }}
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/DaalBot/Discord/security/code-scanning/11](https://github.com/DaalBot/Discord/security/code-scanning/11)

To fix the issue, we will add a `permissions` block to the root of the workflow file. Since the workflow does not require write access to the repository, we will set the `contents` permission to `read`. This limits the `GITHUB_TOKEN` to read-only access, ensuring the workflow adheres to the principle of least privilege.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
